### PR TITLE
2020-07-AC-FixSendEmailConfigFile

### DIFF
--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -28,17 +28,25 @@ class IrMailServer(models.Model):
         elif not smtp_server:
             mail_server = self.sudo().search([], order='sequence', limit=1)
 
-        if mail_server and mail_server.smtp_from:
-            split_from = message['From'].rsplit(' <', 1)
-            if len(split_from) > 1:
-                email_from = '%s <%s>' % (split_from[0], mail_server.smtp_from,)
-            else:
-                email_from = mail_server.smtp_from
-        else:
+        if mail_server:
+            if mail_server.smtp_from:
+                split_from = message['From'].rsplit(' <', 1)
+                if len(split_from) > 1:
+                    email_from = '%s <%s>' % (split_from[0], mail_server.smtp_from,)
+                else:
+                    email_from = mail_server.smtp_from
+        elif odoo.tools.config['email_from']:
             # If we do not have a smtp server defined we
             # look for the email_from parameter from the
             # odoo configuration
-            email_from = odoo.tools.config['email_from']
+            split_from = message['From'].rsplit(' <', 1)
+            if len(split_from) > 1:
+                email_from = '%s <%s>' % (split_from[0], odoo.tools.config['email_from'],)
+            else:
+                email_from = odoo.tools.config['email_from']
+        else:
+            #do nothing
+            pass
 
         if email_from:
             message.replace_header('From', email_from)


### PR DESCRIPTION
Fix1, erroneamente estabamos reemplazando el "from" aún cuando el servidor de correo saliente no estaba configurado un from, dado que tomaba siempre el del archivo de configuracioń de odoo.

Fix2, se reemplaza el "from" con el del archivo de configuración de odoo pero solo si éste está configurado